### PR TITLE
feat(server): redact password field in lease/host database log output

### DIFF
--- a/lib/puppet/type/kea_dhcp_v4_server.rb
+++ b/lib/puppet/type/kea_dhcp_v4_server.rb
@@ -130,6 +130,21 @@ Puppet::Type.newtype(:kea_dhcp_v4_server) do
       normalized
     end
 
+    def is_to_s(current_value) # rubocop:disable Naming/PredicateName
+      redact_password(current_value).inspect
+    end
+
+    def should_to_s(new_value)
+      redact_password(new_value).inspect
+    end
+
+    def redact_password(hash)
+      return hash unless hash.is_a?(Hash) && hash.key?('password')
+
+      hash.merge('password' => 'REDACTED')
+    end
+    private :redact_password
+
     def stringify_keys(hash)
       return {} unless hash.respond_to?(:each)
 
@@ -183,6 +198,21 @@ Puppet::Type.newtype(:kea_dhcp_v4_server) do
       normalized['port'] = Integer(normalized['port'])
       normalized
     end
+
+    def is_to_s(current_value) # rubocop:disable Naming/PredicateName
+      redact_password(current_value).inspect
+    end
+
+    def should_to_s(new_value)
+      redact_password(new_value).inspect
+    end
+
+    def redact_password(hash)
+      return hash unless hash.is_a?(Hash) && hash.key?('password')
+
+      hash.merge('password' => 'REDACTED')
+    end
+    private :redact_password
 
     def stringify_keys(hash)
       return {} unless hash.respond_to?(:each)

--- a/spec/unit/puppet/type/kea_dhcp_v4_server_spec.rb
+++ b/spec/unit/puppet/type/kea_dhcp_v4_server_spec.rb
@@ -161,6 +161,24 @@ describe Puppet::Type.type(:kea_dhcp_v4_server) do
   end
 
   describe 'lease_database property' do
+    it 'redacts the password in is_to_s' do
+      resource = described_class.new(name: 'dhcp4', lease_database: base_lease_db)
+      prop = resource.property(:lease_database)
+      result = prop.is_to_s(resource[:lease_database])
+
+      expect(result).to include('REDACTED')
+      expect(result).not_to include('kea_password')
+    end
+
+    it 'redacts the password in should_to_s' do
+      resource = described_class.new(name: 'dhcp4', lease_database: base_lease_db)
+      prop = resource.property(:lease_database)
+      result = prop.should_to_s(resource[:lease_database])
+
+      expect(result).to include('REDACTED')
+      expect(result).not_to include('kea_password')
+    end
+
     it 'rejects non-hash values' do
       expect {
         described_class.new(name: 'dhcp4', lease_database: 'invalid')
@@ -197,6 +215,37 @@ describe Puppet::Type.type(:kea_dhcp_v4_server) do
           described_class.new(name: 'dhcp4', lease_database: incomplete_db)
         }.to raise_error(Puppet::ResourceError, %r{Lease database #{required_key} must be provided})
       end
+    end
+  end
+
+  describe 'host_database property' do
+    let(:base_host_db) do
+      {
+        'type' => 'postgresql',
+        'name' => 'kea_hosts',
+        'user' => 'kea',
+        'password' => Puppet::Pops::Types::PSensitiveType::Sensitive.new('host_secret'),
+        'host' => '127.0.0.1',
+        'port' => 5432,
+      }
+    end
+
+    it 'redacts the password in is_to_s' do
+      resource = described_class.new(name: 'dhcp4', lease_database: base_lease_db, host_database: base_host_db)
+      prop = resource.property(:host_database)
+      result = prop.is_to_s(resource[:host_database])
+
+      expect(result).to include('REDACTED')
+      expect(result).not_to include('host_secret')
+    end
+
+    it 'redacts the password in should_to_s' do
+      resource = described_class.new(name: 'dhcp4', lease_database: base_lease_db, host_database: base_host_db)
+      prop = resource.property(:host_database)
+      result = prop.should_to_s(resource[:host_database])
+
+      expect(result).to include('REDACTED')
+      expect(result).not_to include('host_secret')
     end
   end
 


### PR DESCRIPTION
Override is_to_s/should_to_s on lease_database and host_database properties to replace the password value with 'REDACTED' in Puppet change notifications. Closes #24.